### PR TITLE
Neko requires a constructor for a class to be injected

### DIFF
--- a/minimal/06_basic_auth/src/auth/Auth.hx
+++ b/minimal/06_basic_auth/src/auth/Auth.hx
@@ -10,6 +10,10 @@ class Auth implements UFAuthHandler
 	// actually stores the user;
 	var _currentUser:User;
 	
+	public function new()
+	{
+	}
+	
 	// initialize our auth handler with an user id,
 	// this user id should be the result of some authentication (e.g. username/password)
 	public function init(userId:String)


### PR DESCRIPTION
As title says,

tried this 6th sample "basic auth" on neko and got an error because the auth handler couldn't be constructed:
`Failed to load UFAuthHandler: $nargs. Using NobodyAuthHandler instead.`
which isn't an instance of `Auth` and therefor `null.init()` didn't work.

Disclaimer: didn't test this on nodejs
